### PR TITLE
Issue8 swagger integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ Nuget/**
 .vs/
 nCrunchTemp*
 *.playlist
+
+#vs code config
+.vscode

--- a/WebApiCoreSeed.WebApi/Controllers/Dtos/ErrorDto.cs
+++ b/WebApiCoreSeed.WebApi/Controllers/Dtos/ErrorDto.cs
@@ -1,0 +1,18 @@
+namespace WebApiCoreSeed.WebApi.Controllers.Dtos
+{
+    /// <summary>
+    /// Error data transfer object
+    /// </summary>
+    internal class ErrorDto
+    {
+        public ErrorDto(string error)
+        {
+            Error = error;
+        }
+
+        /// <summary>
+        /// Error message
+        /// </summary>
+        public string Error { get; private set; }
+    }
+}

--- a/WebApiCoreSeed.WebApi/Controllers/Dtos/ErrorDto.cs
+++ b/WebApiCoreSeed.WebApi/Controllers/Dtos/ErrorDto.cs
@@ -13,6 +13,6 @@ namespace WebApiCoreSeed.WebApi.Controllers.Dtos
         /// <summary>
         /// Error message
         /// </summary>
-        public string Error { get; private set; }
+        public string Error { get; }
     }
 }

--- a/WebApiCoreSeed.WebApi/Controllers/UserController.cs
+++ b/WebApiCoreSeed.WebApi/Controllers/UserController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using WebApiCoreSeed.Data.Models;
 using WebApiCoreSeed.Domain.Services.Interfaces;
@@ -9,6 +10,8 @@ using WebApiCoreSeed.WebApi.Filters;
 namespace WebApiCoreSeed.WebApi.Controllers
 {
     [Route("api/users")]
+    [Produces("Application/json")]
+    [ProducesResponseType(typeof(ErrorDto), 500)]
     public class UserController : Controller
     {
         private readonly IUserService _userService;
@@ -18,15 +21,29 @@ namespace WebApiCoreSeed.WebApi.Controllers
             _userService = userService;
         }
 
-        // GET api/users
+        /// <summary>
+        /// Gets a list of users
+        /// </summary>
+        /// <response code="200">Gets a list of users</response>
+        /// <return>A list of users</return>
         [HttpGet]
+        [Produces("Application/json")]
+        [ProducesResponseType(typeof(List<User>), 200)]
         public async Task<IActionResult> GetAll()
         {
             return Ok(await _userService.GetAsync());
         }
 
-        // GET api/users/0E95A953-D023-4425-ED35-08D4E34D4DB8
+        /// <summary>
+        /// Gets a user based on his id
+        /// </summary>
+        /// <param name="id" cref="Guid">Guid of the user</param>
+        /// <response code="200">The user that has the given id</response>
+        /// <response code="404">User with the given id was not found</response>
+        /// <return>A users</return>
         [HttpGet("{id}")]
+        [ValidateModel]
+        [ProducesResponseType(typeof(User), 200)]
         public async Task<IActionResult> Get(Guid id)
         {
             var user = await _userService.GetByIdAsync(id);
@@ -38,7 +55,12 @@ namespace WebApiCoreSeed.WebApi.Controllers
             return Ok(user);
         }
 
-        // POST api/users
+        /// <summary>
+        /// Creates a new user
+        /// </summary>
+        /// <param name="user" cref="UserDto">User model</param>
+        /// <response code="204">User created</response>
+        /// <response code="404">User could not be created</response>
         [HttpPost]
         [ValidateModel]
         public async Task<IActionResult> Create([FromBody]UserDto user)
@@ -62,7 +84,13 @@ namespace WebApiCoreSeed.WebApi.Controllers
             return affectedRows == 0 ? NotFound() : NoContent() as IActionResult;
         }
 
-        // PUT api/users/0E95A953-D023-4425-ED35-08D4E34D4DB8
+        ///<summary>
+        /// Updates an user given his id
+        ///</summary>
+        ///<param name="id" cref="Guid">Guid of the user</param>
+        ///<param name="user" cref="UserDto">User model</param>
+        ///<response code="204">User created</response>
+        ///<response code="404">User not found / User could not be updated</response>
         [HttpPut("{id}")]
         [ValidateModel]
         public async Task<IActionResult> Update(Guid id, [FromBody]UserDto user)
@@ -85,15 +113,16 @@ namespace WebApiCoreSeed.WebApi.Controllers
             return affectedRows == 0 ? NotFound() : NoContent() as IActionResult;
         }
 
-        // DELETE api/users/0E95A953-D023-4425-ED35-08D4E34D4DB8
+        ///<summary>
+        /// Deletes an user given his id
+        ///</summary>
+        ///<param name="id" cref="Guid">Guid of the user</param>
+        ///<response code="204">User Deleted</response>
+        ///<response code="404">User not found / User could not be deleted</response>
         [HttpDelete("{id}")]
+        [ValidateModel]
         public async Task<IActionResult> Delete(Guid id)
         {
-            if (id == null)
-            {
-                return BadRequest();
-            }
-
             var affectedRows = await _userService.DeleteByIdAsync(id);
 
             return affectedRows == 0 ? NotFound() : NoContent() as IActionResult;

--- a/WebApiCoreSeed.WebApi/Controllers/UserController.cs
+++ b/WebApiCoreSeed.WebApi/Controllers/UserController.cs
@@ -24,10 +24,9 @@ namespace WebApiCoreSeed.WebApi.Controllers
         /// <summary>
         /// Gets a list of users
         /// </summary>
-        /// <response code="200">Gets a list of users</response>
+        /// <response code="200">A list of users</response>
         /// <return>A list of users</return>
         [HttpGet]
-        [Produces("Application/json")]
         [ProducesResponseType(typeof(List<User>), 200)]
         public async Task<IActionResult> GetAll()
         {

--- a/WebApiCoreSeed.WebApi/Filters/ValidateModelAttribute.cs
+++ b/WebApiCoreSeed.WebApi/Filters/ValidateModelAttribute.cs
@@ -1,10 +1,8 @@
-﻿using System.Collections.Generic;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace WebApiCoreSeed.WebApi.Filters
 {
-    [ProducesResponseType(typeof(Dictionary<string, List<string>>), 400)]
     public class ValidateModelAttribute : ActionFilterAttribute
     {
         public override void OnActionExecuting(ActionExecutingContext context)

--- a/WebApiCoreSeed.WebApi/Filters/ValidateModelAttribute.cs
+++ b/WebApiCoreSeed.WebApi/Filters/ValidateModelAttribute.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace WebApiCoreSeed.WebApi.Filters
 {
+    [ProducesResponseType(typeof(Dictionary<string, List<string>>), 400)]
     public class ValidateModelAttribute : ActionFilterAttribute
     {
         public override void OnActionExecuting(ActionExecutingContext context)

--- a/WebApiCoreSeed.WebApi/Filters/ValidateModelResponseOperationFilter.cs
+++ b/WebApiCoreSeed.WebApi/Filters/ValidateModelResponseOperationFilter.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Swashbuckle.AspNetCore.Swagger;
+﻿using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using System.Collections.Generic;
 using System.Linq;

--- a/WebApiCoreSeed.WebApi/Filters/ValidateModelResponseOperationFilter.cs
+++ b/WebApiCoreSeed.WebApi/Filters/ValidateModelResponseOperationFilter.cs
@@ -1,0 +1,44 @@
+﻿using Newtonsoft.Json;
+using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WebApiCoreSeed.WebApi.Filters
+{
+    public class ValidateModelResponseOperationFilter : IOperationFilter
+    {
+        private Dictionary<string, List<string>> responseExample = new Dictionary<string, List<string>>()
+        {
+            {
+                "property1",
+                new List<string>(){"error1", "error2"}
+            },
+            {
+                "property2",
+                new List<string>(){"error1", "error2"}
+            }
+        };
+
+        public void Apply(Operation operation, OperationFilterContext context)
+        {
+            var attributes = context.ApiDescription
+                .ControllerAttributes()
+                .Union(context.ApiDescription.ActionAttributes())
+                .OfType<ValidateModelAttribute>();
+
+            if (attributes.Any())
+            {
+                operation.Responses.Add("400", new Response()
+                {
+                    Description = "Invalid Input",
+                    Schema = new Schema()
+                    {
+                        Example = responseExample
+                    }
+                });
+            }
+
+        }
+    }
+}

--- a/WebApiCoreSeed.WebApi/Middleware/AuthorizationMiddleware.cs
+++ b/WebApiCoreSeed.WebApi/Middleware/AuthorizationMiddleware.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using System.Net;
 using System.Threading.Tasks;
+using WebApiCoreSeed.WebApi.Controllers.Dtos;
 
 namespace WebApiCoreSeed.WebApi.Middleware
 {
@@ -31,7 +32,7 @@ namespace WebApiCoreSeed.WebApi.Middleware
             var isUserBlocked = context.User.HasClaim(c => c.Type == "UserStatus" && c.Value == "Blocked");
             if (isUserBlocked)
             {
-                var message = JsonConvert.SerializeObject(new { error = "Unauthorized" });
+                var message = JsonConvert.SerializeObject(new ErrorDto("Unauthorized"));
                 context.Response.ContentType = "application/json";
                 context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
                 await context.Response.WriteAsync(message);

--- a/WebApiCoreSeed.WebApi/Middleware/ErrorHandlingMiddleware.cs
+++ b/WebApiCoreSeed.WebApi/Middleware/ErrorHandlingMiddleware.cs
@@ -4,6 +4,7 @@ using System;
 using System.Net;
 using System.Threading.Tasks;
 using WebApiCoreSeed.Domain.Exceptions;
+using WebApiCoreSeed.WebApi.Controllers.Dtos;
 
 namespace WebApiCoreSeed.WebApi.Middleware
 {
@@ -48,7 +49,7 @@ namespace WebApiCoreSeed.WebApi.Middleware
             // else if (exception is SomeOtherException) code = HttpStatusCode.RequestTimeout;
             // else if (exception is SomeOtherException2) code = HttpStatusCode.BadRequest;
 
-            var result = JsonConvert.SerializeObject(new { error = exception.Message });
+            var result = JsonConvert.SerializeObject(new ErrorDto(exception.Message));
             context.Response.ContentType = "application/json";
             context.Response.StatusCode = (int)code;
             return context.Response.WriteAsync(result);

--- a/WebApiCoreSeed.WebApi/WebApiCoreSeed.WebApi.csproj
+++ b/WebApiCoreSeed.WebApi/WebApiCoreSeed.WebApi.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
+    <DocumentationFile>bin\Debug\$(TargetFramework)\$(MSBuildProjectName).xml</DocumentationFile>
+    <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +16,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0" />


### PR DESCRIPTION
# First PR on MS c:

## Background  
Implements swagger ui, with swashbuckle as a code generator

## Changes done 
* ErrorDto is added, to have some kind of typing what our api recognizes as an error response.
* ValidateModelResponseOperationFilter is a swagger definitition that is added to the final json for whatever endpoint that uses ValidateModel attribute.
* On webapi csproject \<NoWarn\>1701;1702;1705;1591\</NoWarn\> was added, this is for warnings suppresions on xml comments (\<summary\>), also the generator for that xml is added.