### PR TITLE
removes xunit and inmemorydatabase warnings

### DIFF
--- a/WebApiCoreSeed.UnitTests/Infrastructure/RestClient/RestClientTests.cs
+++ b/WebApiCoreSeed.UnitTests/Infrastructure/RestClient/RestClientTests.cs
@@ -74,8 +74,8 @@ namespace WebApiCoreSeed.UnitTests.Infrastructure.RestClient
             Assert.Null(response.ErrorValue);
             Assert.Equal(HttpStatusCode.Created, response.HttpStatusCode);
             Assert.True(response.IsSuccessResult);
-            Assert.Equal(response.SuccessValue.Id, "test");
-            Assert.Equal(response.SuccessValue.Code, 5);
+            Assert.Equal("test", response.SuccessValue.Id);
+            Assert.Equal(5, response.SuccessValue.Code);
         }
 
         [Fact]
@@ -98,8 +98,8 @@ namespace WebApiCoreSeed.UnitTests.Infrastructure.RestClient
             Assert.IsType<ErrorDto>(response.ErrorValue);
             Assert.Equal(HttpStatusCode.BadRequest, response.HttpStatusCode);
             Assert.False(response.IsSuccessResult);
-            Assert.Equal(response.ErrorValue.ErrorCode, 2);
-            Assert.Equal(response.ErrorValue.ErrorDescription, GenericErrorDescription);
+            Assert.Equal(2, response.ErrorValue.ErrorCode);
+            Assert.Equal(GenericErrorDescription, response.ErrorValue.ErrorDescription);
         }
 
         [Fact]
@@ -123,8 +123,8 @@ namespace WebApiCoreSeed.UnitTests.Infrastructure.RestClient
             Assert.Null(response.ErrorValue);
             Assert.Equal(HttpStatusCode.Created, response.HttpStatusCode);
             Assert.True(response.IsSuccessResult);
-            Assert.Equal(response.SuccessValue.Id, "test");
-            Assert.Equal(response.SuccessValue.Code, 5);
+            Assert.Equal("test", response.SuccessValue.Id);
+            Assert.Equal(5, response.SuccessValue.Code);
         }
 
         [Fact]
@@ -147,8 +147,8 @@ namespace WebApiCoreSeed.UnitTests.Infrastructure.RestClient
             Assert.IsType<ErrorDto>(response.ErrorValue);
             Assert.Equal(HttpStatusCode.BadRequest, response.HttpStatusCode);
             Assert.False(response.IsSuccessResult);
-            Assert.Equal(response.ErrorValue.ErrorCode, 2);
-            Assert.Equal(response.ErrorValue.ErrorDescription, GenericErrorDescription);
+            Assert.Equal(2, response.ErrorValue.ErrorCode);
+            Assert.Equal(GenericErrorDescription, response.ErrorValue.ErrorDescription);
         }
     }
 }

--- a/WebApiCoreSeed.UnitTests/Services/UserServiceTests.cs
+++ b/WebApiCoreSeed.UnitTests/Services/UserServiceTests.cs
@@ -15,7 +15,7 @@ namespace WebApiCoreSeed.UnitTests.Services
         {
             // Arrange
             var optionsBuilder = new DbContextOptionsBuilder<WebApiCoreSeedContext>();
-            optionsBuilder.UseInMemoryDatabase();
+            optionsBuilder.UseInMemoryDatabase("GetByIdAsync_ShouldReturnUser");
             var createdUser =
                 new User
                 {
@@ -54,7 +54,7 @@ namespace WebApiCoreSeed.UnitTests.Services
         {
             // Arrange
             var optionsBuilder = new DbContextOptionsBuilder<WebApiCoreSeedContext>();
-            optionsBuilder.UseInMemoryDatabase();
+            optionsBuilder.UseInMemoryDatabase("GetByIdAsync_ShouldReturnNull");
             User user;
             using (var context = new WebApiCoreSeedContext(optionsBuilder.Options))
             {


### PR DESCRIPTION
## Background  
There was some stray warnings on the solution, we just fix them
## Changes done  
* Changes parameter position on Assert.Equal(expectedValue, actualValue)
* Adds a string on the uses of UseInMemoryDatabase (void value was deprecated)
## Demo 
![build](https://user-images.githubusercontent.com/7729931/39942164-0d1b2188-5535-11e8-87eb-a7e611390dea.PNG)


