### PR TITLE
Post now returns a 201

### DIFF
--- a/Seed.Api.Tests/Controllers/UserControllerTest.cs
+++ b/Seed.Api.Tests/Controllers/UserControllerTest.cs
@@ -82,7 +82,7 @@ namespace Seed.Api.Tests.Controllers
         #region Create Tests
 
         [Fact]
-        public async void Create_ShouldReturnNoContent_WhenUserIsOk()
+        public async void Create_ShouldReturnCreated_WhenUserIsOk()
         {
             var userService = new Mock<IUserService>();
             var classUnderTest = new UserController(userService.Object);
@@ -94,11 +94,14 @@ namespace Seed.Api.Tests.Controllers
                   u.FirstName == userDto.FirstName &&
                   u.LastName == userDto.LastName &&
                   u.UserName == userDto.UserName)))
-                  .ReturnsAsync(1);
+                  .ReturnsAsync(new User()
+                  {
+                      Id = Guid.NewGuid()
+                  });
 
             var result = await classUnderTest.Create(userDto);
 
-            Assert.IsType<NoContentResult>(result);
+            Assert.IsType<CreatedAtActionResult>(result);
             userService.VerifyAll();
         }
 
@@ -111,28 +114,6 @@ namespace Seed.Api.Tests.Controllers
             var result = await classUnderTest.Create(null);
 
             Assert.IsType<BadRequestResult>(result);
-            userService.VerifyAll();
-        }
-
-        [Fact]
-        public async void Create_ShouldReturnNotFound_WhenNoUserWasNotCreated()
-        {
-            var userService = new Mock<IUserService>();
-            var classUnderTest = new UserController(userService.Object);
-
-            var userDto = GetADefaultUserDto();
-
-            userService.Setup(a => a.CreateAsync(It.Is<User>(
-                u =>
-                    u.Email == userDto.Email &&
-                    u.FirstName == userDto.FirstName &&
-                    u.LastName == userDto.LastName &&
-                    u.UserName == userDto.UserName)))
-                .ReturnsAsync(0);
-
-            var result = await classUnderTest.Create(userDto);
-
-            Assert.IsType<NotFoundResult>(result);
             userService.VerifyAll();
         }
 

--- a/Seed.Api/Controllers/UserController.cs
+++ b/Seed.Api/Controllers/UserController.cs
@@ -58,10 +58,11 @@ namespace Seed.Api.Controllers
         /// Creates a new user
         /// </summary>
         /// <param name="user" cref="UserDto">User model</param>
-        /// <response code="204">User created</response>
+        /// <response code="201">User created</response>
         /// <response code="404">User could not be created</response>
         [HttpPost]
         [ValidateModel]
+        [ProducesResponseType(typeof(User), 201)]
         public async Task<IActionResult> Create([FromBody]UserDto user)
         {
             if (user == null)
@@ -69,7 +70,7 @@ namespace Seed.Api.Controllers
                 return BadRequest();
             }
 
-            var affectedRows = await _userService.CreateAsync(new User
+            var userCreated = await _userService.CreateAsync(new User
             {
                 Id = Guid.NewGuid(),
                 Email = user.Email,
@@ -80,7 +81,7 @@ namespace Seed.Api.Controllers
                 // TODO: get createdBy from current user
             });
 
-            return affectedRows == 0 ? NotFound() : NoContent() as IActionResult;
+            return CreatedAtAction("Get", new { id = userCreated.Id }, userCreated);
         }
 
         ///<summary>

--- a/Seed.Domain/Services/Interfaces/IUserService.cs
+++ b/Seed.Domain/Services/Interfaces/IUserService.cs
@@ -22,7 +22,7 @@ namespace Seed.Domain.Services.Interfaces
         /// </summary>
         /// <param name="user">User to create</param>
         /// <returns>An integer indicating the amount of affected rows</returns>
-        Task<int> CreateAsync(User user);
+        Task<User> CreateAsync(User user);
 
         /// <summary>
         /// Deletes a user by Id

--- a/Seed.Domain/Services/UserService.cs
+++ b/Seed.Domain/Services/UserService.cs
@@ -33,11 +33,12 @@ namespace Seed.Domain.Services
             return await _dbContext.Users.ToListAsync();
         }
 
-        public async Task<int> CreateAsync(User user)
+        public async Task<User> CreateAsync(User user)
         {
             user.CreatedOn = DateTime.Now;
-            _dbContext.Users.Add(user);
-            return await _dbContext.SaveChangesAsync();
+            var addEntry = await _dbContext.Users.AddAsync(user);
+            await _dbContext.SaveChangesAsync();
+            return addEntry.Entity;
         }
 
         public async Task<int> UpdateAsync(User user)


### PR DESCRIPTION
## Background

When a client creates a user, they cannot know what id was given
Now with the 201 response, they know what the final result looks like, and also the have a location header, that exposes where the resource was created

## Changes Made

* Updates Controller to return 201
* Updates Service to return the new User
* Updates the unit tests

## Demo
![201created](https://user-images.githubusercontent.com/7729931/40126999-dd5ca88a-5904-11e8-89df-a1076bb16ed8.gif)
