### PR TITLE
Fix failing test, include integration tests project and rename classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ script:
   - dotnet test Seed.Domain.Tests/Seed.Domain.Tests.csproj --configuration release
   - dotnet test Seed.Infrastructure.Tests/Seed.Infrastructure.Tests.csproj --configuration release
   - dotnet test Seed.Api.Tests/Seed.Api.Tests.csproj --configuration release
+  - dotnet test Seed.Api.IntegrationTests/Seed.Api.IntegrationTests.csproj --configuration release
   - dotnet test Seed.Data.Tests/Seed.Data.Tests.csproj --configuration release

--- a/Seed.Api.IntegrationTests/Controllers/UserControllerTests.cs
+++ b/Seed.Api.IntegrationTests/Controllers/UserControllerTests.cs
@@ -108,7 +108,7 @@ namespace Seed.Api.IntegrationTests.Controllers
             var result = await _httpClient.PostAsync(ResouceUri, CreateContent(user));
 
             result.EnsureSuccessStatusCode();
-            Assert.Equal(HttpStatusCode.NoContent, result.StatusCode);
+            Assert.Equal(HttpStatusCode.Created, result.StatusCode);
             using (var dbcontext = CreateContext())
             {
                 Assert.NotNull(dbcontext.Users.FirstOrDefault(a => a.UserName == user.UserName));

--- a/Seed.Api.Tests/Controllers/UserControllerTests.cs
+++ b/Seed.Api.Tests/Controllers/UserControllerTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Seed.Api.Tests.Controllers
 {
-    public class UserControllerTest
+    public class UserControllerTests
     {
         #region GetAll Tests
 

--- a/Seed.Api.Tests/Middleware/AuthorizationMiddlewareTests.cs
+++ b/Seed.Api.Tests/Middleware/AuthorizationMiddlewareTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Seed.Api.Tests.Middleware
 {
-    public class AuthorizationMiddlewareTest 
+    public class AuthorizationMiddlewareTests 
     {
         [Fact]
         public async void Invoke_ShouldInvokeNext_WhenUserIsValid()

--- a/Seed.Api.Tests/Middleware/ErrorHandlingMiddlewareTests.cs
+++ b/Seed.Api.Tests/Middleware/ErrorHandlingMiddlewareTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Seed.Api.Tests.Middleware
 {
-    public class ErrorHandlingMiddlewareTest
+    public class ErrorHandlingMiddlewareTests
     {
         [Fact]
         public async void Invoke_ShouldDoNothing_WhenNextThrowsNoExceptions()

--- a/Seed.Data.Tests/EF/DatabaseSeedTests.cs
+++ b/Seed.Data.Tests/EF/DatabaseSeedTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Seed.Data.Tests.EF
 {
-    public class DatabaseSeedTest
+    public class DatabaseSeedTests
     {
         [Fact]
         public async Task Initialize_ShouldCreateAUser()


### PR DESCRIPTION
## Background

While making some classes/filenames consistent I've found that we were having a failing test but also we didn't notice it because Travis never considered the integration tests project.

## Changes

- Make Travis know about `IntegrationTests` project.
- Fix failing test (controller action was updated but not the test).
- Rename tests classes so the name is consistent with the other files.